### PR TITLE
Add groundcontrol.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ All entries are alphabetized – including by first name when there are multiple
 
 ## Coming soon
 
-| Company                            | Founding ex-GitHubber(s)                                                                                                                    |
-|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| [WorkOn](https://workon.co)        | [Zach Holman](https://github.com/holman)                                                                                                    |
-| [Yetto](https://yetto.app)         | [Brian Levine](https://github.com/balevine), [Garen Torikian](https://github.com/gjtorikian), [Nick Cannariato](https://github.com/birdcar) |
-| [Zipper](https://www.zipper.works) | [Sachin Ranchod](https://github.com/sachinr)                                                                                                |
+| Company                                    | Founding ex-GitHubber(s)                                                                                                                    |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| [GroundControl](https://groundcontrol.sh/) | [Alberto Gimeno](https://github.com/gimenete)                                                                                               |
+| [WorkOn](https://workon.co)                | [Zach Holman](https://github.com/holman)                                                                                                    |
+| [Yetto](https://yetto.app)                 | [Brian Levine](https://github.com/balevine), [Garen Torikian](https://github.com/gjtorikian), [Nick Cannariato](https://github.com/birdcar) |
+| [Zipper](https://www.zipper.works)         | [Sachin Ranchod](https://github.com/sachinr)                                                                                                |
 
 ## No longer involved or moved on
 


### PR DESCRIPTION
I was a githubber from 2018 to 2022!

I became very interested in feature flags as you can read in [this post](https://github.blog/2021-04-27-ship-code-faster-safer-feature-flags/) and now I'm building [GroundControl](https://groundcontrol.sh/).